### PR TITLE
ElectricSpock 0.7.1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ## What's new
 
-The latest version is 0.7. Past history of the library is [over there](history.md).
+The latest version is 0.7.1. Past history of the library is [over there](history.md).
 
-Version 0.7 tested with Robolectric 3.5.1 and Android Gradle Plugin 3.0.1. 
+Version 0.7.1 works with Robolectric 3.6.1. (It does not work with Robolectric 3.6)
 
-_IMPORTANT_: Starting from this version, the library will no longer expose the dependent library implicitly.
+_IMPORTANT_: Starting from version 0.7, the library will no longer expose the dependent library implicitly.
 This means you have to add dependencies of Robolectric, Spock Framework and Groovy explicitly.
 This reduce the chances of version conflict in future. See [Installation](#installation-gradle) for details.
 
@@ -23,7 +23,7 @@ The Android test framework [Robolectric](https://github.com/robolectric/robolect
 
 It is heavily based on RoboSpock project. It borrow a lot of code from there, and make some tweak of my own. This project is never possible without the excellent foundation.
 
-Current version (0.7) of the library is tested with Robolectric 3.5.1.
+Current version (0.7.1) of the library is tested with Robolectric 3.6.1.
 
 # Installation (Gradle)
 
@@ -45,8 +45,9 @@ Add the dependencies
 ```groovy
 	// AGP 3.0
 	dependencies {
-		testImplementation 'com.github.hkhc:electricspock:0.7'
-		testImplementation 'org.robolectric:robolectric:3.5.1'
+		testImplementation 'com.github.hkhc:electricspock:0.7.1'
+		testImplementation 'org.robolectric:robolectric:3.6.1'
+		testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
 		testImplementation 'org.codehaus.groovy:groovy-all:2.4.12'
 		testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
 	}
@@ -54,8 +55,9 @@ Add the dependencies
 ```groovy
 	// pre-AGP 3.0
 	dependencies {
-		testCompile 'com.github.hkhc:electricspock:0.7'
-		testCompile 'org.robolectric:robolectric:3.5.1'
+		testCompile 'com.github.hkhc:electricspock:0.7.1'
+		testCompile 'org.robolectric:robolectric:3.6.1'
+		testCompile 'org.robolectric:shadows-support-v4:3.4-rc2'
 		testCompile 'org.codehaus.groovy:groovy-all:2.4.12'
 		testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/electricspock-core/build.gradle
+++ b/electricspock-core/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     testRuntimeOnly files("build/classes/groovy/test")
     testRuntimeOnly files("build/classes/groovy/main")
 
-    api "org.robolectric:robolectric:3.5.1"
+    api "org.robolectric:robolectric:3.6-alpha-1"
     api 'org.codehaus.groovy:groovy-all:2.4.12'
     api "org.spockframework:spock-core:1.1-groovy-2.4"
 

--- a/electricspock-core/build.gradle
+++ b/electricspock-core/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     testRuntimeOnly files("build/classes/groovy/test")
     testRuntimeOnly files("build/classes/groovy/main")
 
-    api "org.robolectric:robolectric:3.6-alpha-1"
-    api 'org.codehaus.groovy:groovy-all:2.4.12'
+    api "org.robolectric:robolectric:3.6.1"
+    api 'org.codehaus.groovy:groovy-all:2.4.13'
     api "org.spockframework:spock-core:1.1-groovy-2.4"
 
     implementation 'org.jetbrains:annotations-java5:15.0'

--- a/electricspock-core/src/main/java/hkhc/electricspock/RobolectricVersionChecker.java
+++ b/electricspock-core/src/main/java/hkhc/electricspock/RobolectricVersionChecker.java
@@ -29,7 +29,7 @@ public class RobolectricVersionChecker {
     private String versionKey = "robolectric.version";
 
     // *** update this for version upgrade
-    private String[] acceptedVersions = new String[] {"3.3","3.4", "3.5"};
+    private String[] acceptedVersions = new String[] {"3.3","3.4", "3.5", "3.6"};
 
     public RobolectricVersionChecker() {}
 
@@ -87,7 +87,7 @@ public class RobolectricVersionChecker {
 
         if (!isVersion(ver, acceptedVersions))
             throw new RuntimeException(
-                    "This version of ElectricSpock supports Robolectric 3.3.x to 3.5.x only. "
+                    "This version of ElectricSpock supports Robolectric 3.3.x to 3.6.x only. "
                             +"Version "+ver+" is detected.");
     }
 

--- a/electricspock-core/src/test/groovy/hkhc/electricspock/RobolectricVersionCheckerSpec.groovy
+++ b/electricspock-core/src/test/groovy/hkhc/electricspock/RobolectricVersionCheckerSpec.groovy
@@ -79,7 +79,7 @@ class RobolectricVersionCheckerSpec extends ElectricSpecification {
             checker.checkRobolectricVersion(ver)
         then:
             def ex = thrown(RuntimeException)
-            ex.message == "This version of ElectricSpock supports Robolectric 3.3.x to 3.5.x only. Version ${ver} is detected." as String
+            ex.message == "This version of ElectricSpock supports Robolectric 3.3.x to 3.6.x only. Version ${ver} is detected." as String
 
         where:
             ver || _

--- a/electricspock-electricspock/build.gradle
+++ b/electricspock-electricspock/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testRuntimeOnly files("build/classes/groovy/test")
     testRuntimeOnly files("build/classes/groovy/main")
 
-    api 'org.codehaus.groovy:groovy-all:2.4.12'
+    api 'org.codehaus.groovy:groovy-all:2.4.13'
     api "org.spockframework:spock-core:1.1-groovy-2.4"
 
     implementation 'cglib:cglib-nodep:3.2.4'

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,6 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 
-version=0.8-dev
+version=0.7.1
 
 description=Library that bridge Robolectric and Spock framework

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,6 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 
-version=0.7
+version=0.8-dev
 
 description=Library that bridge Robolectric and Spock framework

--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+Version 0.7.1 works with Robolectric 3.6.1. (It does not work with Robolectric 3.6)
+
+Version 0.7 tested with Robolectric 3.5.1 and Android Gradle Plugin 3.0.1. 
+
 Version 0.6 supports @Config annotation of Robolectric, and tested with Robolectric 3.4.2.
 
 Version 0.5 Compatible with Robolectric 3.3.x. Reorganize yet again, maximal reuse of code from RobolectricTestRunner

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     testImplementation project(':electricspock-electricspock')
-    testImplementation 'org.robolectric:robolectric:3.5.1'
+    testImplementation 'org.robolectric:robolectric:3.6-alpha-1'
     testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
     testImplementation 'org.codehaus.groovy:groovy-all:2.4.12'
     testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -81,9 +81,9 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     testImplementation project(':electricspock-electricspock')
-    testImplementation 'org.robolectric:robolectric:3.6-alpha-1'
+    testImplementation 'org.robolectric:robolectric:3.6.1'
     testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
-    testImplementation 'org.codehaus.groovy:groovy-all:2.4.12'
+    testImplementation 'org.codehaus.groovy:groovy-all:2.4.13'
     testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
 
     testImplementation( 'com.athaydes:spock-reports:1.3.2' ) {


### PR DESCRIPTION
Not much is changed. Just update with Robolectric 3.6.1
Robolectric 3.6 has issues with Android Support Test Library, skip to 3.6.1.