### PR TITLE
Update for Robolectric 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
     - build-tools-26.0.2
 
     # The SDK version used to compile your project
-    - android-25
+    - android-26
 
     # Additional components
 #    - extra-google-google_play_services

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## What's new
 
-The latest version is 0.8. Past history of the library is [over there](history.md).
+The latest version is 0.9. Past history of the library is [over there](history.md).
 
 Version 0.8 tested with Robolectric 3.7.1 and Android Gradle Plugin 3.0.1. There is no real code change. Just update version check.
 
@@ -23,14 +23,7 @@ The Android test framework [Robolectric](https://github.com/robolectric/robolect
 
 It is heavily based on RoboSpock project. It borrow a lot of code from there, and make some tweak of my own. This project is never possible without the excellent foundation.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-Current version (0.7.1) of the library is tested with Robolectric 3.6.1.
-=======
-Current version (0.8) of the library is tested with Robolectric 3.7.
->>>>>>> - Update for Robolectric 3.7
-=======
-Current version (0.8) of the library is tested with Robolectric 3.7.1.
+Current version (0.9) of the library is tested with Robolectric 3.8.
 >>>>>>> - test with Robolectric 3.7.1
 
 # Installation (Gradle)
@@ -53,7 +46,7 @@ Add the dependencies
 ```groovy
 	// AGP 3.0
 	dependencies {
-		testImplementation 'com.github.hkhc:electricspock:0.8'
+		testImplementation 'com.github.hkhc:electricspock:0.9'
 		testImplementation 'org.robolectric:robolectric:3.7.1'
 		testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
 		testImplementation 'org.codehaus.groovy:groovy-all:2.4.12'
@@ -63,7 +56,7 @@ Add the dependencies
 ```groovy
 	// pre-AGP 3.0
 	dependencies {
-		testCompile 'com.github.hkhc:electricspock:0.8'
+		testCompile 'com.github.hkhc:electricspock:0.9'
 		testCompile 'org.robolectric:robolectric:3.7.1'
 		testCompile 'org.robolectric:shadows-support-v4:3.4-rc2'
 		testCompile 'org.codehaus.groovy:groovy-all:2.4.12'

--- a/electricspock-core/build.gradle
+++ b/electricspock-core/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     testRuntimeOnly files("build/classes/groovy/test")
     testRuntimeOnly files("build/classes/groovy/main")
 
-    api "org.robolectric:robolectric:3.7.1"
+    api "org.robolectric:robolectric:3.8"
     api 'org.codehaus.groovy:groovy-all:2.4.13'
     api "org.spockframework:spock-core:1.1-groovy-2.4"
 

--- a/electricspock-core/src/main/java/hkhc/electricspock/RobolectricVersionChecker.java
+++ b/electricspock-core/src/main/java/hkhc/electricspock/RobolectricVersionChecker.java
@@ -29,7 +29,7 @@ public class RobolectricVersionChecker {
     private String versionKey = "robolectric.version";
 
     // *** update this for version upgrade
-    private String[] acceptedVersions = new String[] {"3.3","3.4", "3.5", "3.6", "3.7"};
+    private String[] acceptedVersions = new String[] {"3.3","3.4", "3.5", "3.6", "3.7", "3.8"};
 
     public RobolectricVersionChecker() {}
 
@@ -87,7 +87,7 @@ public class RobolectricVersionChecker {
 
         if (!isVersion(ver, acceptedVersions))
             throw new RuntimeException(
-                    "This version of ElectricSpock supports Robolectric 3.3.x to 3.6.x only. "
+                    "This version of ElectricSpock supports Robolectric 3.3.x to 3.8.x only. "
                             +"Version "+ver+" is detected.");
     }
 

--- a/electricspock-core/src/test/groovy/hkhc/electricspock/RobolectricVersionCheckerSpec.groovy
+++ b/electricspock-core/src/test/groovy/hkhc/electricspock/RobolectricVersionCheckerSpec.groovy
@@ -79,7 +79,7 @@ class RobolectricVersionCheckerSpec extends ElectricSpecification {
             checker.checkRobolectricVersion(ver)
         then:
             def ex = thrown(RuntimeException)
-            ex.message == "This version of ElectricSpock supports Robolectric 3.3.x to 3.6.x only. Version ${ver} is detected." as String
+            ex.message == "This version of ElectricSpock supports Robolectric 3.3.x to 3.8.x only. Version ${ver} is detected." as String
 
         where:
             ver || _

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,6 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 
-version=0.8
+version=0.9
 
 description=Library that bridge Robolectric and Spock framework

--- a/history.md
+++ b/history.md
@@ -1,3 +1,5 @@
+Version 0.8 works with Robolectric 3.7.1.
+
 Version 0.7.1 works with Robolectric 3.6.1. (It does not work with Robolectric 3.6)
 
 Version 0.7 tested with Robolectric 3.5.1 and Android Gradle Plugin 3.0.1. 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'groovyx.android'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "26.0.2"
     defaultConfig {
         applicationId "hkhc.electricspock.sample"
@@ -72,16 +72,16 @@ android {
 
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-ads:11.0.4'
+    implementation 'com.google.android.gms:play-services-ads:12.0.1'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
 
     testImplementation 'junit:junit:4.12'
 
     testImplementation project(':electricspock-electricspock')
-    testImplementation 'org.robolectric:robolectric:3.7.1'
+    testImplementation 'org.robolectric:robolectric:3.8'
     testImplementation 'org.robolectric:shadows-support-v4:3.4-rc2'
     testImplementation 'org.codehaus.groovy:groovy-all:2.4.13'
     testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'

--- a/sample/src/test/groovy/hkhc/electricspock/sample/ResourceWithAltManifestSpec.groovy
+++ b/sample/src/test/groovy/hkhc/electricspock/sample/ResourceWithAltManifestSpec.groovy
@@ -45,7 +45,7 @@ class ResourceWithAltManifestSpec extends ElectricSpecification {
 
 
         then:
-            version==11020000
+            version==12211000
 
     }
 
@@ -56,7 +56,7 @@ class ResourceWithAltManifestSpec extends ElectricSpecification {
         when: "Library resource"
         int googlePlayVersion = context.getResources().getInteger(R.integer.google_play_services_version);
         then:
-        googlePlayVersion == 11020000
+        googlePlayVersion == 12211000
     }
 
 }


### PR DESCRIPTION
- update for Robolectric 3.8
- Sample app compile with API level 26
- pump to 0.9